### PR TITLE
Further improvements to operator parsing in lexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## Next
 - Add operator words `plus`, `minus` and `times`
+- Add operator phrases `multiplied by` and `divided by`
+- Add operator symbol `÷`
 - Disallow named number followed by smaller named number (like 1 million thousand)
 - Fix/improve parsing of multi-word units
 - Fix light second parsed as light year
 - Fix `Ω` lexing
+- Fix lexing of rpm units
 
 ## 1.6.0 - 2021 Jul 3
 - Add support for non-US "metre" and "litre" spellings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ pub enum LexerKeyword {
   Hg,
   PoundForce,
   Force,
+  Revolution,
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
- Add support for phrases 'multiplied by' and 'divided by'
- Add support for the division operator symbol ÷
- Fixed lexing of revolutions per minute units