### PR TITLE
turn off decimal dependency default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,6 @@ dependencies = [
  "bitflags",
  "cc",
  "libc",
- "ord_subset",
- "rustc-serialize",
- "serde",
 ]
 
 [[package]]
@@ -57,12 +54,6 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
-name = "ord_subset"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ce14664caf5b27f5656ff727defd68ae1eb75ef3c4d95259361df1eb376bef"
 
 [[package]]
 name = "regex"
@@ -80,18 +71,6 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
-name = "serde"
-version = "1.0.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,8 @@ dependencies = [
  "bitflags",
  "cc",
  "libc",
+ "ord_subset",
+ "serde",
 ]
 
 [[package]]
@@ -54,6 +56,12 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "ord_subset"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ce14664caf5b27f5656ff727defd68ae1eb75ef3c4d95259361df1eb376bef"
 
 [[package]]
 name = "regex"
@@ -71,6 +79,12 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "serde"
+version = "1.0.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,19 @@ homepage = "https://github.com/probablykasper/cpc#readme"
 repository = "https://github.com/probablykasper/cpc"
 documentation = "https://docs.rs/cpc"
 keywords = ["math", "expression", "evaluate", "units", "convert"]
-categories = ["mathematics", "science", "parsing", "text-processing", "value-formatting"]
+categories = [
+    "mathematics",
+    "science",
+    "parsing",
+    "text-processing",
+    "value-formatting",
+]
 
 [dependencies]
-decimal = { version = "2.1", default-features = false }
+decimal = { version = "2.1", default-features = false, features = [
+    "serde",
+    "ord_subset",
+] }
 unicode-segmentation = "1.9"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["math", "expression", "evaluate", "units", "convert"]
 categories = ["mathematics", "science", "parsing", "text-processing", "value-formatting"]
 
 [dependencies]
-decimal = "2.1"
+decimal = { version = "2.1", default-features = false }
 unicode-segmentation = "1.9"
 
 [dev-dependencies]


### PR DESCRIPTION
Hi @probablykasper , 

Since json parsing is not done anyway, can we turn off decimal's default features to get rid of https://rustsec.org/advisories/RUSTSEC-2022-0004?

resolves #32 